### PR TITLE
Now with 60% more transducer!!!

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [aleph "0.4.1-beta2"]
                  [net.cgrand/xforms "0.1.0"]
-                 [com.taoensso/timbre "4.2.0"]]
+                 [com.taoensso/timbre "4.8.0"]]
   :plugins [[lein-cljfmt "0.3.0"]
             [lein-cloverage "1.0.7"]]
   :main ^:skip-aot kegan.core

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [aleph "0.4.1-beta2"]
+                 [aleph "0.4.1"]
                  [net.cgrand/xforms "0.1.0"]
                  [com.taoensso/timbre "4.8.0"]]
   :plugins [[lein-cljfmt "0.3.0"]

--- a/src/kegan/diff.clj
+++ b/src/kegan/diff.clj
@@ -18,6 +18,10 @@
                 [[path v]]))))
          obj)))
 
+(defn ^:private annotate
+  "Annotate ks in a set with the given view fns."
+  [ks & views]
+  (into #{} (map (apply juxt identity views)) ks))
 
 (defn fancy-diff
   [prev curr]
@@ -29,13 +33,13 @@
                                               (map keys)
                                               (map (partial into #{}))
                                               (apply diff))]
-    {:added (->> added-ks (map (juxt identity new)) (into #{}))
-     :changed (->> changed-ks (map (juxt identity old new)) (into #{}))
-     :removed (->> removed-ks (map (juxt identity old)) (into #{}))}))
+    {:added (annotate added-ks new)
+     :changed (annotate changed-ks old new)
+     :removed (annotate removed-ks old)}))
 
 (defn with-sentinel
   "Sometimes, your nested value will always have all keys, but use a
-  sentinel to mean that the real value is unknown"
+  sentinel to mean that the real value is unknown."
   ([fancy-diff]
    (with-sentinel fancy-diff {}))
   ([{:keys [changed] :as fancy-diff}

--- a/src/kegan/diff.clj
+++ b/src/kegan/diff.clj
@@ -9,14 +9,15 @@
   ([obj]
    (entries [] obj))
   ([prefix obj]
-   (->> obj
-        (mapcat
-         (fn [[k v]]
-           (let [path (conj prefix k)]
-             (if (map? v)
-               (entries path v)
-               [[path v]]))))
-        (into #{}))))
+   (into #{}
+         (mapcat
+          (fn [[k v]]
+            (let [path (conj prefix k)]
+              (if (map? v)
+                (entries path v)
+                [[path v]]))))
+         obj)))
+
 
 (defn fancy-diff
   [prev curr]


### PR DESCRIPTION
I would have upgraded the xforms dependency but it appears that has a regression! 😱 

As you can tell from the super great tests this does not affect external behavior but it does mean significantly fewer seqs get created. Performance appears marginally better in cursory tests, but more importantly: 95% percentile garbage collection time is way better (assuming that JVM isn't doing anything besides diffing which is true for all use cases of kegan I know of which I assume is also all use cases of kegan ;))

It'd be great if a release were cut. Come to think of it, I think I still have the only magic keys to do that....